### PR TITLE
Fix indent format.

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,8 +1,8 @@
 [
-	{
-		"keys": ["alt+super+w"], "command": "close_other_windows",
+    {
+        "keys": ["alt+super+w"], "command": "close_other_windows",
         "keys": ["ctrl+super+w"], "command": "close_other_tabs"
-		
-	}
-	
+
+    }
+
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,8 +1,8 @@
 [
-	{
-		"keys": ["alt+super+w"], "command": "close_other_windows",
+    {
+        "keys": ["alt+super+w"], "command": "close_other_windows",
         "keys": ["ctrl+super+w"], "command": "close_other_tabs"
-		
-	}
-	
+
+    }
+
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,8 +1,8 @@
 [
-	{
-		"keys": ["alt+super+w"], "command": "close_other_windows",
+    {
+        "keys": ["alt+super+w"], "command": "close_other_windows",
         "keys": ["ctrl+super+w"], "command": "close_other_tabs"
-		
-	}
-	
+
+    }
+
 ]


### PR DESCRIPTION
There are mixed tabs and spaces for indent in the kepmap files.

And when I open it with Sublime Text, I saw the two lines are not aligned.

This commit fixed the format issue.

😀
