### PR TITLE
[Fix] warning: mnemonic f not found in menu caption File

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,7 +1,7 @@
 [
     {
         "caption": "File",
-        "mnemonic": "f",
+        "mnemonic": "F",
         "id": "file",
         "children":
         [


### PR DESCRIPTION
### 1. Behavior before pull request

I get unexpected messages in Sublime Text console.

```shell
warning: mnemonic f not found in menu caption File
```

Example:

```python
reloading settings Packages/TabsExtra/tabs_extra.sublime-settings
reloading settings Packages/User/Package Control.sublime-settings
warning: mnemonic f not found in menu caption File
reloading settings Packages/User/Preferences.sublime-settings
warning: mnemonic f not found in menu caption File
reloading settings Packages/User/Fetch.sublime-settings
warning: mnemonic f not found in menu caption File
Package Control: Upgraded FavoriteFiles to 1.5.0
reloading plugin FavoriteFiles.favorite_files
reloading plugin FavoriteFiles.favorites
reloading plugin FavoriteFiles.support
warning: mnemonic f not found in menu caption File
warning: mnemonic f not found in menu caption File
reloading settings Packages/User/Package Control.sublime-settings
reloading settings Packages/User/Preferences.sublime-settings
warning: mnemonic f not found in menu caption File
Package Control: Upgraded GitGutter to 1.7.1
reloading settings Packages/User/Preferences.sublime-settings
warning: mnemonic f not found in menu caption File
Package Control: Upgraded TabsExtra to 1.4.0
```

### 2. Behavior after pull request

No unexpected messages in console.

### 3. Argumentation

I don't want unexpected messages in console.

### 4. Testing environment

**Operating system and version:**
Windows 10 Enterprise LTSB 64-bit EN
**Sublime Text:**
Build 3126
**Package:**
The latest stable version of CloseOtherWindows for Sublime Text 3

### 5. Examples on other apps

I fix this problem in [**5 Sublime Text packages**](https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+author%3AKristinita+mnemonic).

Thanks.